### PR TITLE
fix: user_configurations failing to deserialize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub use trend::Trend;
 mod stream;
 pub use stream::*;
 
+mod serde;
+
 fn request(method: &str, address: &str) -> Request {
     dotenv().ok();
     let id_key = std::env::var("APCA_API_KEY_ID").expect("API Id Key Not Found");

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,21 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Deserializer};
+
+pub fn deserialize_to_string_map<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let map: Option<HashMap<String, serde_json::Value>> = Option::deserialize(deserializer)?;
+    if let Some(map) = map {
+        let transformed_map = map
+            .into_iter()
+            .map(|(key, value)| (key, value.to_string().trim_matches('"').to_string()))
+            .collect();
+        Ok(Some(transformed_map))
+    } else {
+        Ok(None)
+    }
+}

--- a/src/trading/account.rs
+++ b/src/trading/account.rs
@@ -21,6 +21,7 @@ pub struct AccountConfiguration {
 pub struct Account {
     pub id: String,
     pub admin_configurations: HashMap<String, String>,
+    #[serde(deserialize_with = "crate::serde::deserialize_to_string_map")]
     pub user_configurations: Option<HashMap<String, String>>,
     pub account_number: String,
     pub status: String,


### PR DESCRIPTION
Hi there, I absolutely love your library for rust and plan to use it for a while so I've made this quick fix as it seems get_account is broken. 

I've implemented the fix in a non-breaking way but just a FYI, if you wanted,  `user_configurations` could be changed to type `AccountConfiguration` and deserialize fine :)

Let me know if you want any further changes. I ran the all the tests and it seems like some other things are broken